### PR TITLE
remove showMonths options

### DIFF
--- a/content/options.md
+++ b/content/options.md
@@ -253,12 +253,6 @@ An always up-to-date list of options may be found at <a href="https://github.com
             <td>Show the month using the shorthand version (ie, Sep instead of September).</td>
         </tr>
         <tr>
-            <td>showMonths</td>
-            <td>Integer</td>
-            <td>1</td>
-            <td>The number of months showed.</td>
-        </tr>
-        <tr>
             <td>static</td>
             <td>Boolean</td>
             <td>false</td>


### PR DESCRIPTION
# background
showMonths options is displayed twice.
<img width="901" alt="Options - flatpickr 2020-09-28 22-18-27" src="https://user-images.githubusercontent.com/8898432/94437345-963bd780-01d8-11eb-940e-5f158a26d487.png">